### PR TITLE
Add saju bot sample

### DIFF
--- a/saju-bot/App.tsx
+++ b/saju-bot/App.tsx
@@ -1,0 +1,551 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { v4 as uuidv4 } from "uuid";
+
+import Image from "next/image";
+
+// UI components
+import Transcript from "./components/Transcript";
+import Events from "./components/Events";
+import BottomToolbar from "./components/BottomToolbar";
+
+// Types
+import { SessionStatus } from "@/app/types";
+import type { RealtimeAgent } from '@openai/agents/realtime';
+
+// Context providers & hooks
+import { useTranscript } from "@/app/contexts/TranscriptContext";
+import { useEvent } from "@/app/contexts/EventContext";
+import { useRealtimeSession } from "./hooks/useRealtimeSession";
+import { createModerationGuardrail } from "@/app/agentConfigs/guardrails";
+
+// Agent configs
+import { allAgentSets, defaultAgentSetKey } from "@/app/agentConfigs";
+import { customerServiceRetailScenario } from "@/app/agentConfigs/customerServiceRetail";
+import { chatSupervisorScenario } from "@/app/agentConfigs/chatSupervisor";
+import { customerServiceRetailCompanyName } from "@/app/agentConfigs/customerServiceRetail";
+import { chatSupervisorCompanyName } from "@/app/agentConfigs/chatSupervisor";
+import { simpleHandoffScenario } from "@/app/agentConfigs/simpleHandoff";
+
+// Map used by connect logic for scenarios defined via the SDK.
+const sdkScenarioMap: Record<string, RealtimeAgent[]> = {
+  simpleHandoff: simpleHandoffScenario,
+  customerServiceRetail: customerServiceRetailScenario,
+  chatSupervisor: chatSupervisorScenario,
+};
+
+import useAudioDownload from "./hooks/useAudioDownload";
+import { useHandleSessionHistory } from "./hooks/useHandleSessionHistory";
+
+function App() {
+  const searchParams = useSearchParams()!;
+
+  // ---------------------------------------------------------------------
+  // Codec selector – lets you toggle between wide-band Opus (48 kHz)
+  // and narrow-band PCMU/PCMA (8 kHz) to hear what the agent sounds like on
+  // a traditional phone line and to validate ASR / VAD behaviour under that
+  // constraint.
+  //
+  // We read the `?codec=` query-param and rely on the `changePeerConnection`
+  // hook (configured in `useRealtimeSession`) to set the preferred codec
+  // before the offer/answer negotiation.
+  // ---------------------------------------------------------------------
+  const urlCodec = searchParams.get("codec") || "opus";
+
+  // Agents SDK doesn't currently support codec selection so it is now forced 
+  // via global codecPatch at module load 
+
+  const {
+    addTranscriptMessage,
+    addTranscriptBreadcrumb,
+  } = useTranscript();
+  const { logClientEvent, logServerEvent } = useEvent();
+
+  const [selectedAgentName, setSelectedAgentName] = useState<string>("");
+  const [selectedAgentConfigSet, setSelectedAgentConfigSet] = useState<
+    RealtimeAgent[] | null
+  >(null);
+
+  const audioElementRef = useRef<HTMLAudioElement | null>(null);
+  // Ref to identify whether the latest agent switch came from an automatic handoff
+  const handoffTriggeredRef = useRef(false);
+
+  const sdkAudioElement = React.useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    const el = document.createElement('audio');
+    el.autoplay = true;
+    el.style.display = 'none';
+    document.body.appendChild(el);
+    return el;
+  }, []);
+
+  // Attach SDK audio element once it exists (after first render in browser)
+  useEffect(() => {
+    if (sdkAudioElement && !audioElementRef.current) {
+      audioElementRef.current = sdkAudioElement;
+    }
+  }, [sdkAudioElement]);
+
+  const {
+    connect,
+    disconnect,
+    sendUserText,
+    sendEvent,
+    interrupt,
+    mute,
+  } = useRealtimeSession({
+    onConnectionChange: (s) => setSessionStatus(s as SessionStatus),
+    onAgentHandoff: (agentName: string) => {
+      handoffTriggeredRef.current = true;
+      setSelectedAgentName(agentName);
+    },
+  });
+
+  const [sessionStatus, setSessionStatus] =
+    useState<SessionStatus>("DISCONNECTED");
+
+  const [isEventsPaneExpanded, setIsEventsPaneExpanded] =
+    useState<boolean>(true);
+  const [userText, setUserText] = useState<string>("");
+  const [isPTTActive, setIsPTTActive] = useState<boolean>(false);
+  const [isPTTUserSpeaking, setIsPTTUserSpeaking] = useState<boolean>(false);
+  const [isAudioPlaybackEnabled, setIsAudioPlaybackEnabled] = useState<boolean>(
+    () => {
+      if (typeof window === 'undefined') return true;
+      const stored = localStorage.getItem('audioPlaybackEnabled');
+      return stored ? stored === 'true' : true;
+    },
+  );
+
+  // Initialize the recording hook.
+  const { startRecording, stopRecording, downloadRecording } =
+    useAudioDownload();
+
+  const sendClientEvent = (eventObj: any, eventNameSuffix = "") => {
+    try {
+      sendEvent(eventObj);
+      logClientEvent(eventObj, eventNameSuffix);
+    } catch (err) {
+      console.error('Failed to send via SDK', err);
+    }
+  };
+
+  useHandleSessionHistory();
+
+  useEffect(() => {
+    let finalAgentConfig = searchParams.get("agentConfig");
+    if (!finalAgentConfig || !allAgentSets[finalAgentConfig]) {
+      finalAgentConfig = defaultAgentSetKey;
+      const url = new URL(window.location.toString());
+      url.searchParams.set("agentConfig", finalAgentConfig);
+      window.location.replace(url.toString());
+      return;
+    }
+
+    const agents = allAgentSets[finalAgentConfig];
+    const agentKeyToUse = agents[0]?.name || "";
+
+    setSelectedAgentName(agentKeyToUse);
+    setSelectedAgentConfigSet(agents);
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (selectedAgentName && sessionStatus === "DISCONNECTED") {
+      connectToRealtime();
+    }
+  }, [selectedAgentName]);
+
+  useEffect(() => {
+    if (
+      sessionStatus === "CONNECTED" &&
+      selectedAgentConfigSet &&
+      selectedAgentName
+    ) {
+      const currentAgent = selectedAgentConfigSet.find(
+        (a) => a.name === selectedAgentName
+      );
+      addTranscriptBreadcrumb(`Agent: ${selectedAgentName}`, currentAgent);
+      updateSession(!handoffTriggeredRef.current);
+      // Reset flag after handling so subsequent effects behave normally
+      handoffTriggeredRef.current = false;
+    }
+  }, [selectedAgentConfigSet, selectedAgentName, sessionStatus]);
+
+  useEffect(() => {
+    if (sessionStatus === "CONNECTED") {
+      updateSession();
+    }
+  }, [isPTTActive]);
+
+  const fetchEphemeralKey = async (): Promise<string | null> => {
+    logClientEvent({ url: "/session" }, "fetch_session_token_request");
+    const tokenResponse = await fetch("/api/session");
+    const data = await tokenResponse.json();
+    logServerEvent(data, "fetch_session_token_response");
+
+    if (!data.client_secret?.value) {
+      logClientEvent(data, "error.no_ephemeral_key");
+      console.error("No ephemeral key provided by the server");
+      setSessionStatus("DISCONNECTED");
+      return null;
+    }
+
+    return data.client_secret.value;
+  };
+
+  const connectToRealtime = async () => {
+    const agentSetKey = searchParams.get("agentConfig") || "default";
+    if (sdkScenarioMap[agentSetKey]) {
+      if (sessionStatus !== "DISCONNECTED") return;
+      setSessionStatus("CONNECTING");
+
+      try {
+        const EPHEMERAL_KEY = await fetchEphemeralKey();
+        if (!EPHEMERAL_KEY) return;
+
+        // Ensure the selectedAgentName is first so that it becomes the root
+        const reorderedAgents = [...sdkScenarioMap[agentSetKey]];
+        const idx = reorderedAgents.findIndex((a) => a.name === selectedAgentName);
+        if (idx > 0) {
+          const [agent] = reorderedAgents.splice(idx, 1);
+          reorderedAgents.unshift(agent);
+        }
+
+        const companyName = agentSetKey === 'customerServiceRetail'
+          ? customerServiceRetailCompanyName
+          : chatSupervisorCompanyName;
+        const guardrail = createModerationGuardrail(companyName);
+
+        await connect({
+          getEphemeralKey: async () => EPHEMERAL_KEY,
+          initialAgents: reorderedAgents,
+          audioElement: sdkAudioElement,
+          outputGuardrails: [guardrail],
+          extraContext: {
+            addTranscriptBreadcrumb,
+          },
+        });
+      } catch (err) {
+        console.error("Error connecting via SDK:", err);
+        setSessionStatus("DISCONNECTED");
+      }
+      return;
+    }
+  };
+
+  const disconnectFromRealtime = () => {
+    disconnect();
+    setSessionStatus("DISCONNECTED");
+    setIsPTTUserSpeaking(false);
+  };
+
+  const sendSimulatedUserMessage = (text: string) => {
+    const id = uuidv4().slice(0, 32);
+    addTranscriptMessage(id, "user", text, true);
+
+    sendClientEvent({
+      type: 'conversation.item.create',
+      item: {
+        id,
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text }],
+      },
+    });
+    sendClientEvent({ type: 'response.create' }, '(simulated user text message)');
+  };
+
+  const updateSession = (shouldTriggerResponse: boolean = false) => {
+    // Reflect Push-to-Talk UI state by (de)activating server VAD on the
+    // backend. The Realtime SDK supports live session updates via the
+    // `session.update` event.
+    const turnDetection = isPTTActive
+      ? null
+      : {
+          type: 'server_vad',
+          threshold: 0.5,
+          prefix_padding_ms: 300,
+          silence_duration_ms: 500,
+          create_response: true,
+        };
+
+    sendEvent({
+      type: 'session.update',
+      session: {
+        turn_detection: turnDetection,
+      },
+    });
+
+    // Send an initial 'hi' message to trigger the agent to greet the user
+    if (shouldTriggerResponse) {
+      sendSimulatedUserMessage('hi');
+    }
+    return;
+  }
+
+  const handleSendTextMessage = () => {
+    if (!userText.trim()) return;
+    interrupt();
+
+    try {
+      sendUserText(userText.trim());
+    } catch (err) {
+      console.error('Failed to send via SDK', err);
+    }
+
+    setUserText("");
+  };
+
+  const handleTalkButtonDown = () => {
+    if (sessionStatus !== 'CONNECTED') return;
+    interrupt();
+
+    setIsPTTUserSpeaking(true);
+    sendClientEvent({ type: 'input_audio_buffer.clear' }, 'clear PTT buffer');
+
+    // No placeholder; we'll rely on server transcript once ready.
+  };
+
+  const handleTalkButtonUp = () => {
+    if (sessionStatus !== 'CONNECTED' || !isPTTUserSpeaking)
+      return;
+
+    setIsPTTUserSpeaking(false);
+    sendClientEvent({ type: 'input_audio_buffer.commit' }, 'commit PTT');
+    sendClientEvent({ type: 'response.create' }, 'trigger response PTT');
+  };
+
+  const onToggleConnection = () => {
+    if (sessionStatus === "CONNECTED" || sessionStatus === "CONNECTING") {
+      disconnectFromRealtime();
+      setSessionStatus("DISCONNECTED");
+    } else {
+      connectToRealtime();
+    }
+  };
+
+  const handleAgentChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newAgentConfig = e.target.value;
+    const url = new URL(window.location.toString());
+    url.searchParams.set("agentConfig", newAgentConfig);
+    window.location.replace(url.toString());
+  };
+
+  const handleSelectedAgentChange = (
+    e: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const newAgentName = e.target.value;
+    // Reconnect session with the newly selected agent as root so that tool
+    // execution works correctly.
+    disconnectFromRealtime();
+    setSelectedAgentName(newAgentName);
+    // connectToRealtime will be triggered by effect watching selectedAgentName
+  };
+
+  // Because we need a new connection, refresh the page when codec changes
+  const handleCodecChange = (newCodec: string) => {
+    const url = new URL(window.location.toString());
+    url.searchParams.set("codec", newCodec);
+    window.location.replace(url.toString());
+  };
+
+  useEffect(() => {
+    const storedPushToTalkUI = localStorage.getItem("pushToTalkUI");
+    if (storedPushToTalkUI) {
+      setIsPTTActive(storedPushToTalkUI === "true");
+    }
+    const storedLogsExpanded = localStorage.getItem("logsExpanded");
+    if (storedLogsExpanded) {
+      setIsEventsPaneExpanded(storedLogsExpanded === "true");
+    }
+    const storedAudioPlaybackEnabled = localStorage.getItem(
+      "audioPlaybackEnabled"
+    );
+    if (storedAudioPlaybackEnabled) {
+      setIsAudioPlaybackEnabled(storedAudioPlaybackEnabled === "true");
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("pushToTalkUI", isPTTActive.toString());
+  }, [isPTTActive]);
+
+  useEffect(() => {
+    localStorage.setItem("logsExpanded", isEventsPaneExpanded.toString());
+  }, [isEventsPaneExpanded]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "audioPlaybackEnabled",
+      isAudioPlaybackEnabled.toString()
+    );
+  }, [isAudioPlaybackEnabled]);
+
+  useEffect(() => {
+    if (audioElementRef.current) {
+      if (isAudioPlaybackEnabled) {
+        audioElementRef.current.muted = false;
+        audioElementRef.current.play().catch((err) => {
+          console.warn("Autoplay may be blocked by browser:", err);
+        });
+      } else {
+        // Mute and pause to avoid brief audio blips before pause takes effect.
+        audioElementRef.current.muted = true;
+        audioElementRef.current.pause();
+      }
+    }
+
+    // Toggle server-side audio stream mute so bandwidth is saved when the
+    // user disables playback. 
+    try {
+      mute(!isAudioPlaybackEnabled);
+    } catch (err) {
+      console.warn('Failed to toggle SDK mute', err);
+    }
+  }, [isAudioPlaybackEnabled]);
+
+  // Ensure mute state is propagated to transport right after we connect or
+  // whenever the SDK client reference becomes available.
+  useEffect(() => {
+    if (sessionStatus === 'CONNECTED') {
+      try {
+        mute(!isAudioPlaybackEnabled);
+      } catch (err) {
+        console.warn('mute sync after connect failed', err);
+      }
+    }
+  }, [sessionStatus, isAudioPlaybackEnabled]);
+
+  useEffect(() => {
+    if (sessionStatus === "CONNECTED" && audioElementRef.current?.srcObject) {
+      // The remote audio stream from the audio element.
+      const remoteStream = audioElementRef.current.srcObject as MediaStream;
+      startRecording(remoteStream);
+    }
+
+    // Clean up on unmount or when sessionStatus is updated.
+    return () => {
+      stopRecording();
+    };
+  }, [sessionStatus]);
+
+  const agentSetKey = searchParams.get("agentConfig") || "default";
+
+  return (
+    <div className="text-base flex flex-col h-screen bg-gray-100 text-gray-800 relative">
+      <div className="p-5 text-lg font-semibold flex justify-between items-center">
+        <div
+          className="flex items-center cursor-pointer"
+          onClick={() => window.location.reload()}
+        >
+          <div>
+            <Image
+              src="/openai-logomark.svg"
+              alt="OpenAI Logo"
+              width={20}
+              height={20}
+              className="mr-2"
+            />
+          </div>
+          <div>
+            Realtime API <span className="text-gray-500">Agents</span>
+          </div>
+        </div>
+        <div className="flex items-center">
+          <label className="flex items-center text-base gap-1 mr-2 font-medium">
+            Scenario
+          </label>
+          <div className="relative inline-block">
+            <select
+              value={agentSetKey}
+              onChange={handleAgentChange}
+              className="appearance-none border border-gray-300 rounded-lg text-base px-2 py-1 pr-8 cursor-pointer font-normal focus:outline-none"
+            >
+              {Object.keys(allAgentSets).map((agentKey) => (
+                <option key={agentKey} value={agentKey}>
+                  {agentKey}
+                </option>
+              ))}
+            </select>
+            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2 text-gray-600">
+              <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M5.23 7.21a.75.75 0 011.06.02L10 10.44l3.71-3.21a.75.75 0 111.04 1.08l-4.25 3.65a.75.75 0 01-1.04 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+
+          {agentSetKey && (
+            <div className="flex items-center ml-6">
+              <label className="flex items-center text-base gap-1 mr-2 font-medium">
+                Agent
+              </label>
+              <div className="relative inline-block">
+                <select
+                  value={selectedAgentName}
+                  onChange={handleSelectedAgentChange}
+                  className="appearance-none border border-gray-300 rounded-lg text-base px-2 py-1 pr-8 cursor-pointer font-normal focus:outline-none"
+                >
+                  {selectedAgentConfigSet?.map((agent) => (
+                    <option key={agent.name} value={agent.name}>
+                      {agent.name}
+                    </option>
+                  ))}
+                </select>
+                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2 text-gray-600">
+                  <svg
+                    className="h-4 w-4"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5.23 7.21a.75.75 0 011.06.02L10 10.44l3.71-3.21a.75.75 0 111.04 1.08l-4.25 3.65a.75.75 0 01-1.04 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-1 gap-2 px-2 overflow-hidden relative">
+        <Transcript
+          userText={userText}
+          setUserText={setUserText}
+          onSendMessage={handleSendTextMessage}
+          downloadRecording={downloadRecording}
+          canSend={
+            sessionStatus === "CONNECTED"
+          }
+        />
+
+        <Events isExpanded={isEventsPaneExpanded} />
+      </div>
+
+      <BottomToolbar
+        sessionStatus={sessionStatus}
+        onToggleConnection={onToggleConnection}
+        isPTTActive={isPTTActive}
+        setIsPTTActive={setIsPTTActive}
+        isPTTUserSpeaking={isPTTUserSpeaking}
+        handleTalkButtonDown={handleTalkButtonDown}
+        handleTalkButtonUp={handleTalkButtonUp}
+        isEventsPaneExpanded={isEventsPaneExpanded}
+        setIsEventsPaneExpanded={setIsEventsPaneExpanded}
+        isAudioPlaybackEnabled={isAudioPlaybackEnabled}
+        setIsAudioPlaybackEnabled={setIsAudioPlaybackEnabled}
+        codec={urlCodec}
+        onCodecChange={handleCodecChange}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/saju-bot/README.md
+++ b/saju-bot/README.md
@@ -1,0 +1,17 @@
+# Saju Bot
+
+Sample code for a fortune-telling voice bot using OpenAI Realtime API.
+
+Contents:
+- `agentConfigs/saju.ts`: Realtime agent configuration with `get_todays_fortune` tool and Korean prompt.
+- `agentConfigs/index.ts`: Scenario map exposing `saju` agent set.
+- `api/todays_fortune/route.ts`: Next.js route bridging to the Python script.
+- `todays_fortune.py`: Helper script invoking the external fortune API.
+- `hooks/useRealtimeSession.ts`: Realtime session hook with model `gpt-4o-realtime-preview-2025-08-12`.
+- `App.tsx`: Example app component with server VAD threshold `0.5`.
+
+Run lint to validate:
+```bash
+npm test  # (no tests defined)
+npm run lint
+```

--- a/saju-bot/agentConfigs/index.ts
+++ b/saju-bot/agentConfigs/index.ts
@@ -1,0 +1,8 @@
+import type { RealtimeAgent } from '@openai/agents/realtime';
+import { sajuScenario } from './saju';
+
+export const allAgentSets: Record<string, RealtimeAgent[]> = {
+  saju: sajuScenario,
+};
+
+export const defaultAgentSetKey = 'saju';

--- a/saju-bot/agentConfigs/saju.ts
+++ b/saju-bot/agentConfigs/saju.ts
@@ -1,0 +1,89 @@
+import { tool, RealtimeAgent } from '@openai/agents/realtime';
+
+export const getTodaysFortune = tool({
+  name: 'get_todays_fortune',
+  description: 'Retrieve today\u2019s fortune based on birthday, birthtime, gender, optional today/date override.',
+  parameters: {
+    type: 'object',
+    properties: {
+      birthday: {
+        type: 'string',
+        description: 'Birth date in YYYY-MM-DD format.',
+      },
+      birthtime: {
+        type: 'string',
+        description: 'Birth time in HH:MM (24-hour) format.',
+      },
+      gender: {
+        type: 'string',
+        description: "Gender, 'M' for male or 'F' for female.",
+        enum: ['M', 'F'],
+      },
+      today: {
+        type: 'string',
+        description: "Optional override for today's date in YYYY-MM-DD format.",
+      },
+      timeout: {
+        type: 'number',
+        description: 'Network timeout in seconds. Defaults to 15.0.',
+      },
+    },
+    required: [],
+  },
+  execute: async (args) => {
+    const res = await fetch('/api/todays_fortune', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(args),
+    });
+    return await res.json();
+  },
+});
+
+export const sajuAgent = new RealtimeAgent({
+  name: 'sajuFortune',
+  voice: 'Cedar',
+  instructions: `## 리얼 타임 api prompt
+
+모든 말투는 경상도 사투리로 진행 해줘. 경상도 억양을 살린 한국 사주 무속인으로 행동하세요. 사용자의 생년월일과 태어난 시간을 받아, 사주팔자와 그 해석을 단호하고 여운있는 짧은 문장(5~20자)으로 전달합니다. 친근하지만 예언가다운 분위기, 자연에 빗댄 표현, 정해진 무속인 어휘와 경상도식 추임새, 여운이 남는 말끝, 한 문단에 한가지 핵심만 담아 말하세요.
+
+# 역할 및 규칙
+
+- '사주, 팔자, 기운, 운세, 인연줄, 재물줄, 양기, 음기, 복, 화' 등의 어휘 활용.
+- “허허~”, “흐음~”, “아이고”, “그라모” 등 경상도 추임새 사용.
+- 각 문장은 5~20자로 단호하거나 여운이 느껴지게(문장 끝 잠시 멈추는 느낌).
+- 긴 설명은 여러 턴으로 나누고, 핵심은 한 번에 하나.
+- 계절, 날씨, 불, 바람, 물 등 자연 비유 적극 활용.
+- 예언가답고 장중하지만 친근한 말투(장중+정감).
+- 말의 흐름, 기운, 운세 등을 반드시 언급.
+- 반말과 존댓말 혼용 가능하나, 너무 딱딱하거나 멀게 느껴지지 않게.
+- 모든 말투는 경상도 사투리로 진행 해줘. 
+
+# 대화 진행 방식
+
+1. **첫 인사**: 손님 맞이, 생년월일·태어난 시 요청  
+   - 예시: "허허~ 왔구마. 기운 봐줄 준비 됐나? 생년월일이랑 태어난 시, 알려주소."
+2. **기운 확인**: 계절, 시간의 기운 한 줄로 평가  
+   - 예시: "봄기운에 태어났네. 양기 가득허이~"
+3. **관심사 질문**: 연애, 재물, 건강 중 궁금 분야 유도  
+   - 예시: "어디가 제일 궁금한교? 연애, 재물, 건강?"
+4. **분야별 풀이**  
+   - 연애: 인연줄, 마음, 시기  
+   - 재물: 돈줄, 기회, 조심할 점  
+   - 건강: 몸 기운, 병조심, 생활습관  
+5. **마무리/다음 유도**: 짧은 경고나 격려, 추가질문 유도  
+   - 예시: "기운은 좋다. 허지만 욕심은 줄이라."
+
+# Notes
+
+- 답변이 길어지면 반드시 여러 턴으로 나누세요.
+- 자연 비유, 기운/흐름/운세 언급은 필수.
+- 추임새와 경상도 억양, 어휘를 모든 답변에서 사용하세요.
+- 톤: 장중하지만 친근하고, 사투리 느낌 살리기.  
+- 대화 주도, 추가 질문 유도, 모든 안내는 짧고 단호해야 함.
+- 절대 영어·장황한 설명 금지.
+- 절대적으로 경상도 사투리로.`,
+  tools: [getTodaysFortune],
+});
+
+export const sajuScenario = [sajuAgent];

--- a/saju-bot/api/todays_fortune/route.ts
+++ b/saju-bot/api/todays_fortune/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { spawn } from 'child_process';
+import path from 'path';
+
+export async function POST(req: NextRequest) {
+  const { birthday, birthtime, gender, today, timeout } = await req.json();
+  const script = path.join(process.cwd(), 'saju-bot', 'todays_fortune.py');
+  const args = ['--birthday', birthday, '--birthtime', birthtime, '--gender', gender];
+  if (today) args.push('--today', today);
+  if (timeout) args.push('--timeout', String(timeout));
+
+  return await new Promise((resolve) => {
+    const proc = spawn('python', [script, ...args]);
+    let out = '';
+    proc.stdout.on('data', (d) => (out += d));
+    proc.on('close', () => {
+      const parsed = /== Parsed ==\n([\s\S]*)$/.exec(out);
+      resolve(
+        NextResponse.json(parsed ? JSON.parse(parsed[1]) : { error: 'parse failed' }),
+      );
+    });
+  });
+}

--- a/saju-bot/hooks/useRealtimeSession.ts
+++ b/saju-bot/hooks/useRealtimeSession.ts
@@ -1,0 +1,209 @@
+import { useCallback, useRef, useState, useEffect } from 'react';
+import {
+  RealtimeSession,
+  RealtimeAgent,
+  OpenAIRealtimeWebRTC,
+} from '@openai/agents/realtime';
+
+import { audioFormatForCodec, applyCodecPreferences } from '../lib/codecUtils';
+import { useEvent } from '../contexts/EventContext';
+import { useHandleSessionHistory } from './useHandleSessionHistory';
+import { SessionStatus } from '../types';
+
+export interface RealtimeSessionCallbacks {
+  onConnectionChange?: (status: SessionStatus) => void;
+  onAgentHandoff?: (agentName: string) => void;
+}
+
+export interface ConnectOptions {
+  getEphemeralKey: () => Promise<string>;
+  initialAgents: RealtimeAgent[];
+  audioElement?: HTMLAudioElement;
+  extraContext?: Record<string, any>;
+  outputGuardrails?: any[];
+}
+
+export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
+  const sessionRef = useRef<RealtimeSession | null>(null);
+  const [status, setStatus] = useState<
+    SessionStatus
+  >('DISCONNECTED');
+  const { logClientEvent } = useEvent();
+
+  const updateStatus = useCallback(
+    (s: SessionStatus) => {
+      setStatus(s);
+      callbacks.onConnectionChange?.(s);
+      logClientEvent({}, s);
+    },
+    [callbacks],
+  );
+
+  const { logServerEvent } = useEvent();
+
+  const historyHandlers = useHandleSessionHistory().current;
+
+  function handleTransportEvent(event: any) {
+    // Handle additional server events that aren't managed by the session
+    switch (event.type) {
+      case "conversation.item.input_audio_transcription.completed": {
+        historyHandlers.handleTranscriptionCompleted(event);
+        break;
+      }
+      case "response.audio_transcript.done": {
+        historyHandlers.handleTranscriptionCompleted(event);
+        break;
+      }
+      case "response.audio_transcript.delta": {
+        historyHandlers.handleTranscriptionDelta(event);
+        break;
+      }
+      default: {
+        logServerEvent(event);
+        break;
+      } 
+    }
+  }
+
+  const codecParamRef = useRef<string>(
+    (typeof window !== 'undefined'
+      ? (new URLSearchParams(window.location.search).get('codec') ?? 'opus')
+      : 'opus')
+      .toLowerCase(),
+  );
+
+  // Wrapper to pass current codec param
+  const applyCodec = useCallback(
+    (pc: RTCPeerConnection) => applyCodecPreferences(pc, codecParamRef.current),
+    [],
+  );
+
+  const handleAgentHandoff = (item: any) => {
+    const history = item.context.history;
+    const lastMessage = history[history.length - 1];
+    const agentName = lastMessage.name.split("transfer_to_")[1];
+    callbacks.onAgentHandoff?.(agentName);
+  };
+
+  useEffect(() => {
+    if (sessionRef.current) {
+      // Log server errors
+      sessionRef.current.on("error", (...args: any[]) => {
+        logServerEvent({
+          type: "error",
+          message: args[0],
+        });
+      });
+
+      // history events
+      sessionRef.current.on("agent_handoff", handleAgentHandoff);
+      sessionRef.current.on("agent_tool_start", historyHandlers.handleAgentToolStart);
+      sessionRef.current.on("agent_tool_end", historyHandlers.handleAgentToolEnd);
+      sessionRef.current.on("history_updated", historyHandlers.handleHistoryUpdated);
+      sessionRef.current.on("history_added", historyHandlers.handleHistoryAdded);
+      sessionRef.current.on("guardrail_tripped", historyHandlers.handleGuardrailTripped);
+
+      // additional transport events
+      sessionRef.current.on("transport_event", handleTransportEvent);
+    }
+  }, [sessionRef.current]);
+
+  const connect = useCallback(
+    async ({
+      getEphemeralKey,
+      initialAgents,
+      audioElement,
+      extraContext,
+      outputGuardrails,
+    }: ConnectOptions) => {
+      if (sessionRef.current) return; // already connected
+
+      updateStatus('CONNECTING');
+
+      const ek = await getEphemeralKey();
+      const rootAgent = initialAgents[0];
+
+      // This lets you use the codec selector in the UI to force narrow-band (8 kHz) codecs to
+      //  simulate how the voice agent sounds over a PSTN/SIP phone call.
+      const codecParam = codecParamRef.current;
+      const audioFormat = audioFormatForCodec(codecParam);
+
+      sessionRef.current = new RealtimeSession(rootAgent, {
+        transport: new OpenAIRealtimeWebRTC({
+          audioElement,
+          // Set preferred codec before offer creation
+          changePeerConnection: async (pc: RTCPeerConnection) => {
+            applyCodec(pc);
+            return pc;
+          },
+        }),
+        model: 'gpt-4o-realtime-preview-2025-08-12',
+        config: {
+          inputAudioFormat: audioFormat,
+          outputAudioFormat: audioFormat,
+          inputAudioTranscription: {
+            model: 'gpt-4o-mini-transcribe',
+          },
+        },
+        outputGuardrails: outputGuardrails ?? [],
+        context: extraContext ?? {},
+      });
+
+      await sessionRef.current.connect({ apiKey: ek });
+      updateStatus('CONNECTED');
+    },
+    [callbacks, updateStatus],
+  );
+
+  const disconnect = useCallback(() => {
+    sessionRef.current?.close();
+    sessionRef.current = null;
+    updateStatus('DISCONNECTED');
+  }, [updateStatus]);
+
+  const assertconnected = () => {
+    if (!sessionRef.current) throw new Error('RealtimeSession not connected');
+  };
+
+  /* ----------------------- message helpers ------------------------- */
+
+  const interrupt = useCallback(() => {
+    sessionRef.current?.interrupt();
+  }, []);
+  
+  const sendUserText = useCallback((text: string) => {
+    assertconnected();
+    sessionRef.current!.sendMessage(text);
+  }, []);
+
+  const sendEvent = useCallback((ev: any) => {
+    sessionRef.current?.transport.sendEvent(ev);
+  }, []);
+
+  const mute = useCallback((m: boolean) => {
+    sessionRef.current?.mute(m);
+  }, []);
+
+  const pushToTalkStart = useCallback(() => {
+    if (!sessionRef.current) return;
+    sessionRef.current.transport.sendEvent({ type: 'input_audio_buffer.clear' } as any);
+  }, []);
+
+  const pushToTalkStop = useCallback(() => {
+    if (!sessionRef.current) return;
+    sessionRef.current.transport.sendEvent({ type: 'input_audio_buffer.commit' } as any);
+    sessionRef.current.transport.sendEvent({ type: 'response.create' } as any);
+  }, []);
+
+  return {
+    status,
+    connect,
+    disconnect,
+    sendUserText,
+    sendEvent,
+    mute,
+    pushToTalkStart,
+    pushToTalkStop,
+    interrupt,
+  } as const;
+}

--- a/saju-bot/todays_fortune.py
+++ b/saju-bot/todays_fortune.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+# Allow running without installing the package
+sys.path.insert(0, str((Path(__file__).resolve().parents[1] / "src")))
+
+from saju import todays_fortune
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Try saju.todays_fortune API")
+    parser.add_argument("--birthday", required=True, help="YYYY-MM-DD")
+    parser.add_argument("--birthtime", required=True, help="HH:MM (24h)")
+    parser.add_argument("--gender", required=True, choices=["M", "F"], help="M or F")
+    parser.add_argument(
+        "--today",
+        help="Override today's date as YYYY-MM-DD (optional)",
+    )
+    parser.add_argument("--timeout", type=float, default=15.0, help="Network timeout seconds")
+    args = parser.parse_args()
+
+    today_date = None
+    if args.today:
+        today_date = datetime.strptime(args.today, "%Y-%m-%d").date()
+
+    try:
+        result = todays_fortune.get(
+            birthday=args.birthday,
+            birthtime=args.birthtime,
+            gender=args.gender,
+            today_date=today_date,
+            timeout_seconds=args.timeout,
+        )
+    except Exception as e:
+        print(f"Request failed: {e}")
+        return 1
+
+    print("== Request payload ==")
+    print(json.dumps(result.request_payload, ensure_ascii=False, indent=2))
+
+    print("\n== Parsed ==")
+    print(json.dumps(result.parsed, ensure_ascii=False, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add saju bot sample showing Realtime API fortune teller agent
- include API route and Python bridge
- document usage and updated model/VAD settings

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_i_68a9670e81ec8327895a1d5707a9b732