### PR TITLE
Remove upload demo and ensure API routes use Node runtime

### DIFF
--- a/src/app/api/responses/route.ts
+++ b/src/app/api/responses/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import OpenAI from 'openai';
 
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
 // Proxy endpoint for the OpenAI Responses API
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
 export async function GET() {
   try {
     const response = await fetch(


### PR DESCRIPTION
## Summary
- remove the temporary upload API route and demo page that aren't needed for Vercel deployment
- configure `/api/session` and `/api/responses` to explicitly use the Node runtime with increased max duration for compatibility on Vercel
- drop the unused `@vercel/blob` dependency

## Testing
- `npm run lint` *(fails: existing unused variable errors in customerServiceRetail agent configs)*

------
https://chatgpt.com/codex/tasks/task_i_68af266498708327b7b5a57f38c609cc